### PR TITLE
added calender navigation

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -253,26 +253,28 @@ export default function HomeScreen() {
           </Note>
 
           {/* Events — yellow strip, slightly warmer paper */}
-          <Note tilt="right" color={C.magnetYellow} bg={C.noteAlt} style={{ flex: 0.9 }}>
-            <Text style={styles.noteLabel}>COMING UP</Text>
-            <Text style={styles.noteTitle}>Calendar</Text>
+          <Pressable onPress={() => router.push('/(tabs)/calendar')} style={{ flex: 0.9 }}>
+            <Note tilt="right" color={C.magnetYellow} bg={C.noteAlt} style={{ flex: 1 }}>
+              <Text style={styles.noteLabel}>COMING UP</Text>
+              <Text style={styles.noteTitle}>Calendar</Text>
 
-            {eventsLoading ? (
-              <Text style={styles.noteMeta}>Loading…</Text>
-            ) : events.length === 0 ? (
-              <Text style={styles.noteMeta}>All clear!</Text>
-            ) : (
-              events.map((e) => (
-                <View key={e.id} style={styles.eventRow}>
-                  <View style={[styles.eventDot, { backgroundColor: e.color }]} />
-                  <View style={{ flex: 1 }}>
-                    <Text style={styles.eventTitle} numberOfLines={1}>{e.title}</Text>
-                    <Text style={styles.eventTime}>{formatEventTime(e.startTime)}</Text>
+              {eventsLoading ? (
+                <Text style={styles.noteMeta}>Loading…</Text>
+              ) : events.length === 0 ? (
+                <Text style={styles.noteMeta}>All clear!</Text>
+              ) : (
+                events.map((e) => (
+                  <View key={e.id} style={styles.eventRow}>
+                    <View style={[styles.eventDot, { backgroundColor: e.color }]} />
+                    <View style={{ flex: 1 }}>
+                      <Text style={styles.eventTitle} numberOfLines={1}>{e.title}</Text>
+                      <Text style={styles.eventTime}>{formatEventTime(e.startTime)}</Text>
+                    </View>
                   </View>
-                </View>
-              ))
-            )}
-          </Note>
+                ))
+              )}
+            </Note>
+          </Pressable>
         </View>
 
         {/* ── Filler: scattered emoji magnets ─────────────────────────────


### PR DESCRIPTION
Close #10
- wrapped the Calendar Note in a <Pressable> and added onPress to call router.push('/(tabs)/calendar')
- Moved flex: 0.9 into <Pressable> for presaable to fill the space of the notes
- Gave Flex: 1 to <Note> to fill its new parent