### PR TITLE
new switch house route

### DIFF
--- a/app/(auth)/join-house.tsx
+++ b/app/(auth)/join-house.tsx
@@ -8,6 +8,7 @@ import {
   Platform,
 } from 'react-native';
 import { useState } from 'react';
+import { useLocalSearchParams } from 'expo-router';
 import { z } from 'zod';
 import {
   collection,
@@ -33,7 +34,8 @@ const createSchema = z.object({
 });
 
 export default function JoinHouseScreen() {
-  const [mode, setMode] = useState<'join' | 'create'>('join');
+  const { mode: modeParam } = useLocalSearchParams<{ mode?: string }>();
+  const [mode, setMode] = useState<'join' | 'create'>(modeParam === 'create' ? 'create' : 'join');
   const [inviteCodeInput, setInviteCodeInput] = useState('');
   const [houseNameInput, setHouseNameInput] = useState('');
   const [joinValidationError, setJoinValidationError] = useState<string | null>(null);

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -15,7 +15,7 @@ const TABS: { name: string; title: string; icon: IconName; activeIcon: IconName 
   { name: 'settings', title: 'Settings', icon: 'settings-outline', activeIcon: 'settings' },
 ];
 
-const HIDDEN = ['chores', 'calendar', 'two'];
+const HIDDEN = ['chores', 'calendar', 'two', 'house'];
 const TAB_THEME: Record<string, TabTheme> = {
   index: { headerBg: '#FFE3B8', headerTint: '#4A2C1A', tabActive: '#A7572D' },
   pantry: { headerBg: '#DDF4E7', headerTint: '#154D37', tabActive: '#1B8F63' },

--- a/app/(tabs)/house.tsx
+++ b/app/(tabs)/house.tsx
@@ -43,7 +43,7 @@ export default function HouseScreen() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Join a different house"
-            onPress={() => router.push('/(auth)/join-house')}
+            onPress={() => router.push('/(auth)/join-house?mode=join')}
             style={({ pressed }) => [styles.optionButton, pressed && styles.optionButtonPressed]}
           >
             <Text style={styles.optionButtonText}>Go</Text>
@@ -61,7 +61,7 @@ export default function HouseScreen() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Create a new house"
-            onPress={() => router.push('/(auth)/join-house')}
+            onPress={() => router.push('/(auth)/join-house?mode=create')}
             style={({ pressed }) => [styles.optionButton, pressed && styles.optionButtonPressed]}
           >
             <Text style={styles.optionButtonText}>Go</Text>

--- a/app/(tabs)/house.tsx
+++ b/app/(tabs)/house.tsx
@@ -1,0 +1,116 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+const G = {
+  bg: '#FFFBF5',
+  textPrimary: '#2D3436',
+  textSecondary: '#636e72',
+  border: '#DFE6E9',
+  cardBg: '#FFFFFF',
+};
+
+export default function HouseScreen() {
+  const router = useRouter();
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      <View style={styles.container}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+          onPress={() => router.back()}
+          style={({ pressed }) => [styles.backRow, pressed && styles.backRowPressed]}
+        >
+          <Ionicons name="chevron-back" size={20} color={G.textPrimary} />
+          <Text style={styles.backLabel}>Settings</Text>
+        </Pressable>
+
+        <Text style={styles.title}>Switch House</Text>
+        <Text style={styles.subtitle}>
+          Leave your current house first, then join or create a new one.
+        </Text>
+
+        <View style={styles.optionCard}>
+          <View style={styles.optionIconWrap}>
+            <Ionicons name="mail-open-outline" size={22} color={G.textPrimary} />
+          </View>
+          <View style={styles.optionBody}>
+            <Text style={styles.optionTitle}>Join a different house</Text>
+            <Text style={styles.optionDesc}>Enter an invite code from a housemate.</Text>
+          </View>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Join a different house"
+            onPress={() => router.push('/(auth)/join-house')}
+            style={({ pressed }) => [styles.optionButton, pressed && styles.optionButtonPressed]}
+          >
+            <Text style={styles.optionButtonText}>Go</Text>
+          </Pressable>
+        </View>
+
+        <View style={styles.optionCard}>
+          <View style={styles.optionIconWrap}>
+            <Ionicons name="add-circle-outline" size={22} color={G.textPrimary} />
+          </View>
+          <View style={styles.optionBody}>
+            <Text style={styles.optionTitle}>Create a new house</Text>
+            <Text style={styles.optionDesc}>Start fresh and invite your housemates.</Text>
+          </View>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Create a new house"
+            onPress={() => router.push('/(auth)/join-house')}
+            style={({ pressed }) => [styles.optionButton, pressed && styles.optionButtonPressed]}
+          >
+            <Text style={styles.optionButtonText}>Go</Text>
+          </Pressable>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: G.bg },
+  container: { flex: 1, padding: 20 },
+  backRow: { flexDirection: 'row', alignItems: 'center', gap: 4, marginBottom: 20, alignSelf: 'flex-start' },
+  backRowPressed: { opacity: 0.6 },
+  backLabel: { color: G.textPrimary, fontWeight: '600' },
+  title: { fontSize: 26, fontWeight: '800', color: G.textPrimary, marginBottom: 8 },
+  subtitle: { color: G.textSecondary, lineHeight: 20, marginBottom: 24 },
+  optionCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    borderWidth: 1.5,
+    borderColor: G.border,
+    borderRadius: 12,
+    backgroundColor: G.cardBg,
+    padding: 16,
+    marginBottom: 12,
+  },
+  optionIconWrap: {
+    width: 38,
+    height: 38,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: G.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  optionBody: { flex: 1 },
+  optionTitle: { fontSize: 15, fontWeight: '700', color: G.textPrimary },
+  optionDesc: { color: G.textSecondary, marginTop: 2, fontSize: 13 },
+  optionButton: {
+    borderRadius: 8,
+    borderWidth: 1.5,
+    borderColor: G.border,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    backgroundColor: G.bg,
+  },
+  optionButtonPressed: { opacity: 0.7 },
+  optionButtonText: { fontWeight: '700', color: G.textPrimary },
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -53,6 +53,9 @@ export default function SettingsScreen() {
       });
       batch.update(userDoc(currentUid), { houseId: deleteField() });
       await batch.commit();
+      const profile = useAuthStore.getState().userProfile;
+      if (profile) useAuthStore.getState().setUserProfile({ ...profile, houseId: null });
+      useHouseStore.getState().setHouse(null);
     } catch (err) {
       const message = (err as { message?: string })?.message ?? 'Could not leave house. Please try again.';
       setLeaveError(message);

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -29,6 +29,30 @@ const S = {
 export default function SettingsScreen() {
   const [isSigningOut, setIsSigningOut] = useState(false);
 
+  function handleLeaveHouse() {
+    // TODO(#4): wire real leave-house mutation here
+    console.log('[Settings] leave house – placeholder, no Firestore writes yet');
+  }
+
+  async function confirmLeaveHouse() {
+    if (Platform.OS === 'web') {
+      const confirmed = globalThis.confirm?.(
+        "Leave house?\n\nYou'll be removed from this house and will need an invite code to rejoin."
+      );
+      if (confirmed) handleLeaveHouse();
+    } else {
+      Alert.alert(
+        'Leave house?',
+        "You'll be removed from this house and will need an invite code to rejoin.",
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Leave house', style: 'destructive', onPress: handleLeaveHouse },
+        ]
+      );
+      
+    }
+  }
+
   const router = useRouter();
   const house = useHouseStore((s) => s.house);
   const memberMap = useHouseStore((s) => s.memberMap);
@@ -126,6 +150,32 @@ export default function SettingsScreen() {
                     </Text>
                   </View>
                 ))}
+              </View>
+
+              <View style={styles.houseActionRow}>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Switch house"
+                  onPress={() => router.push('/(tabs)/house')}
+                  style={({ pressed }) => [
+                    styles.secondaryButton,
+                    pressed && styles.secondaryButtonPressed,
+                  ]}
+                >
+                  <Text style={styles.secondaryButtonText}>Switch house</Text>
+                </Pressable>
+
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Leave house"
+                  onPress={confirmLeaveHouse}
+                  style={({ pressed }) => [
+                    styles.leaveButton,
+                    pressed && styles.leaveButtonPressed,
+                  ]}
+                >
+                  <Text style={styles.leaveButtonText}>Leave house</Text>
+                </Pressable>
               </View>
             </View>
           ) : houseId && !house ? (
@@ -263,6 +313,33 @@ const styles = StyleSheet.create({
   colorDot: { width: 10, height: 10, borderRadius: 5 },
   memberName: { color: S.textStrong, fontWeight: '600' },
   houseLoading: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  houseActionRow: { marginTop: 14, flexDirection: 'row', gap: 10 },
+  secondaryButton: {
+    flex: 1,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: S.cardBorder,
+    backgroundColor: '#FFFFFF',
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  secondaryButtonPressed: { opacity: 0.75 },
+  secondaryButtonText: { color: S.textStrong, fontWeight: '700' },
+  leaveButton: {
+    flex: 1,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: S.dangerBorder,
+    backgroundColor: S.dangerBg,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  leaveButtonPressed: { opacity: 0.75 },
+  leaveButtonText: { color: S.dangerText, fontWeight: '700' },
   ctaButton: {
     marginTop: 14,
     borderRadius: 12,

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -11,7 +11,11 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { arrayRemove, deleteField, writeBatch } from 'firebase/firestore';
+
+import { db } from '@/src/firebase/config';
 import { signOut } from '@/src/firebase/auth';
+import { houseDoc, userDoc } from '@/src/firebase/firestore';
 import { useAuthStore } from '@/src/store/authStore';
 import { useHouseStore } from '@/src/store/houseStore';
 
@@ -28,10 +32,36 @@ const S = {
 
 export default function SettingsScreen() {
   const [isSigningOut, setIsSigningOut] = useState(false);
+  const [isLeavingHouse, setIsLeavingHouse] = useState(false);
+  const [leaveError, setLeaveError] = useState<string | null>(null);
 
-  function handleLeaveHouse() {
-    // TODO(#4): wire real leave-house mutation here
-    console.log('[Settings] leave house – placeholder, no Firestore writes yet');
+  const router = useRouter();
+  const house = useHouseStore((s) => s.house);
+  const memberMap = useHouseStore((s) => s.memberMap);
+  const houseId = useAuthStore((s) => s.userProfile?.houseId ?? null);
+  const currentUid = useAuthStore((s) => s.firebaseUser?.uid ?? null);
+
+  async function handleLeaveHouse() {
+    if (!currentUid || !houseId) return;
+    setLeaveError(null);
+    setIsLeavingHouse(true);
+    try {
+      const batch = writeBatch(db);
+      batch.update(houseDoc(houseId), {
+        memberIds: arrayRemove(currentUid),
+        [`memberNames.${currentUid}`]: deleteField(),
+      });
+      batch.update(userDoc(currentUid), { houseId: deleteField() });
+      await batch.commit();
+    } catch (err) {
+      const message = (err as { message?: string })?.message ?? 'Could not leave house. Please try again.';
+      setLeaveError(message);
+      if (Platform.OS !== 'web') {
+        Alert.alert('Error', message);
+      }
+    } finally {
+      setIsLeavingHouse(false);
+    }
   }
 
   async function confirmLeaveHouse() {
@@ -39,7 +69,7 @@ export default function SettingsScreen() {
       const confirmed = globalThis.confirm?.(
         "Leave house?\n\nYou'll be removed from this house and will need an invite code to rejoin."
       );
-      if (confirmed) handleLeaveHouse();
+      if (confirmed) await handleLeaveHouse();
     } else {
       Alert.alert(
         'Leave house?',
@@ -49,15 +79,8 @@ export default function SettingsScreen() {
           { text: 'Leave house', style: 'destructive', onPress: handleLeaveHouse },
         ]
       );
-      
     }
   }
-
-  const router = useRouter();
-  const house = useHouseStore((s) => s.house);
-  const memberMap = useHouseStore((s) => s.memberMap);
-  const houseId = useAuthStore((s) => s.userProfile?.houseId ?? null);
-  const currentUid = useAuthStore((s) => s.firebaseUser?.uid ?? null);
 
   // Prefer the live memberMap (has color + displayName). 
   const members = useMemo(() => {
@@ -169,14 +192,24 @@ export default function SettingsScreen() {
                   accessibilityRole="button"
                   accessibilityLabel="Leave house"
                   onPress={confirmLeaveHouse}
+                  disabled={isLeavingHouse}
                   style={({ pressed }) => [
                     styles.leaveButton,
-                    pressed && styles.leaveButtonPressed,
+                    isLeavingHouse && styles.leaveButtonDisabled,
+                    pressed && !isLeavingHouse && styles.leaveButtonPressed,
                   ]}
                 >
-                  <Text style={styles.leaveButtonText}>Leave house</Text>
+                  {isLeavingHouse ? (
+                    <View style={styles.signOutButtonInner}>
+                      <ActivityIndicator />
+                      <Text style={styles.leaveButtonText}>Leaving…</Text>
+                    </View>
+                  ) : (
+                    <Text style={styles.leaveButtonText}>Leave house</Text>
+                  )}
                 </Pressable>
               </View>
+              {leaveError && <Text style={styles.errorText}>{leaveError}</Text>}
             </View>
           ) : houseId && !house ? (
             <View style={[styles.card, styles.houseLoading]}>
@@ -353,4 +386,6 @@ const styles = StyleSheet.create({
   },
   ctaButtonPressed: { opacity: 0.85 },
   ctaButtonText: { color: '#FFFFFF', fontWeight: '800' },
+  leaveButtonDisabled: { opacity: 0.6 },
+  errorText: { color: S.dangerText, fontSize: 12, marginTop: 8 },
 });


### PR DESCRIPTION
closed #3 

What does this change do?
- added two new buttons at settings, switch house and leave house. 
- switch house lead to /house route, and in there user can choose to switch houses by joining a new one or creating a brand new one
- leaving house requires confirmation.  
Why is it needed?
- people getting new roommates will require them to switch houses
What did you test?
- i tested all routes and all is working
<img width="910" height="410" alt="Screenshot 2026-04-20 at 2 34 47 PM" src="https://github.com/user-attachments/assets/b6451fd2-444a-44b3-a6d3-63570514ff71" />
<img width="608" height="1350" alt="Screenshot 2026-04-20 at 2 34 43 PM" src="https://github.com/user-attachments/assets/41d17649-77f4-4f54-ab9f-272f1de3df04" />
<img width="602" height="1328" alt="Screenshot 2026-04-20 at 2 34 40 PM" src="https://github.com/user-attachments/assets/b0540f0c-53eb-4361-bda2-d4950b673980" />

