### PR TITLE
feat: Google Calendar sync via device calendar for assigned events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "date-fns": "^4.1.0",
         "expo": "~54.0.33",
         "expo-auth-session": "~7.0.10",
+        "expo-calendar": "~15.0.8",
         "expo-camera": "~17.0.10",
         "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.13",
@@ -5342,6 +5343,16 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-calendar": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-calendar/-/expo-calendar-15.0.8.tgz",
+      "integrity": "sha512-i+ojy6zFnWSPb2DYp4L4W4U5iVI+NXnuHr3xysShoV8znNOmixP1TOYuJXt5Lpz+BpHCWseU31gV1E5SSkIKsw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-camera": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "date-fns": "^4.1.0",
     "expo": "~54.0.33",
     "expo-auth-session": "~7.0.10",
+    "expo-calendar": "~15.0.8",
     "expo-camera": "~17.0.10",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",

--- a/src/components/calendar/EventCard.tsx
+++ b/src/components/calendar/EventCard.tsx
@@ -1,12 +1,14 @@
 import { View, Text, StyleSheet } from 'react-native';
 import { format } from 'date-fns';
 import type { CalendarEvent } from '@/src/types';
+import { useHouseStore } from '@/src/store/houseStore';
 
 interface Props {
   event: CalendarEvent;
 }
 
 export function EventCard({ event }: Props) {
+  const memberMap = useHouseStore((s) => s.memberMap);
   const start = event.startTime.toDate();
   const end = event.endTime.toDate();
   const timeRange = `${format(start, 'h:mm a')} – ${format(end, 'h:mm a')}`;
@@ -16,6 +18,21 @@ export function EventCard({ event }: Props) {
       <Text style={styles.title}>{event.title}</Text>
       <Text style={styles.time}>{timeRange}</Text>
       {!!event.description && <Text style={styles.desc}>{event.description}</Text>}
+      {event.assignedTo?.length > 0 && (
+        <View style={styles.assigneeRow}>
+          {event.assignedTo.map((uid) => {
+            const member = memberMap[uid];
+            if (!member) return null;
+            return (
+              <View key={uid} style={[styles.dot, { backgroundColor: member.color }]}>
+                <Text style={styles.initial}>
+                  {member.displayName.charAt(0).toUpperCase()}
+                </Text>
+              </View>
+            );
+          })}
+        </View>
+      )}
     </View>
   );
 }
@@ -35,4 +52,13 @@ const styles = StyleSheet.create({
   title: { fontSize: 15, fontWeight: '600', color: '#2D3436' },
   time: { fontSize: 12, color: '#636e72', marginTop: 2 },
   desc: { fontSize: 12, color: '#636e72', marginTop: 4, fontStyle: 'italic' },
+  assigneeRow: { flexDirection: 'row', gap: 4, marginTop: 8 },
+  dot: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  initial: { color: '#fff', fontSize: 11, fontWeight: '700' },
 });

--- a/src/components/calendar/EventForm.tsx
+++ b/src/components/calendar/EventForm.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   StyleSheet,
   Alert,
+  ScrollView,
 } from 'react-native';
 import BottomSheet, {
   BottomSheetModal,
@@ -15,6 +16,7 @@ import BottomSheet, {
 } from '@gorhom/bottom-sheet';
 import { parse, isValid } from 'date-fns';
 import type { NewEventInput } from '@/src/hooks/useCalendarEvents';
+import { useHouseStore } from '@/src/store/houseStore';
 
 interface Props {
   onSubmit: (input: NewEventInput) => Promise<void>;
@@ -25,20 +27,30 @@ export const EventForm = forwardRef<BottomSheetModal, Props>(({ onSubmit }, ref)
   const [description, setDescription] = useState('');
   const [startTimeStr, setStartTimeStr] = useState('');
   const [endTimeStr, setEndTimeStr] = useState('');
+  const [assignedTo, setAssignedTo] = useState<string[]>([]);
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
+
+  const memberMap = useHouseStore((s) => s.memberMap);
 
   const reset = () => {
     setTitle('');
     setDescription('');
     setStartTimeStr('');
     setEndTimeStr('');
+    setAssignedTo([]);
     setError('');
   };
 
   const parseDateTime = (str: string): Date | null => {
     const d = parse(str.trim(), 'yyyy-MM-dd HH:mm', new Date());
     return isValid(d) ? d : null;
+  };
+
+  const toggleAssignee = (uid: string) => {
+    setAssignedTo((prev) =>
+      prev.includes(uid) ? prev.filter((id) => id !== uid) : [...prev, uid]
+    );
   };
 
   const handleSubmit = async () => {
@@ -68,7 +80,13 @@ export const EventForm = forwardRef<BottomSheetModal, Props>(({ onSubmit }, ref)
 
     setSubmitting(true);
     try {
-      await onSubmit({ title: title.trim(), description: description.trim(), startTime, endTime });
+      await onSubmit({
+        title: title.trim(),
+        description: description.trim(),
+        startTime,
+        endTime,
+        assignedTo,
+      });
       reset();
       (ref as React.RefObject<BottomSheetModal>).current?.dismiss();
     } catch (err: any) {
@@ -85,10 +103,12 @@ export const EventForm = forwardRef<BottomSheetModal, Props>(({ onSubmit }, ref)
     []
   );
 
+  const memberIds = Object.keys(memberMap);
+
   return (
     <BottomSheetModal
       ref={ref}
-      snapPoints={['70%']}
+      snapPoints={['75%']}
       backdropComponent={renderBackdrop}
       keyboardBehavior="extend"
       keyboardBlurBehavior="restore"
@@ -114,6 +134,33 @@ export const EventForm = forwardRef<BottomSheetModal, Props>(({ onSubmit }, ref)
           multiline
           numberOfLines={2}
         />
+
+        {memberIds.length > 0 && (
+          <View style={styles.assigneeSection}>
+            <Text style={styles.label}>Assign To</Text>
+            <View style={styles.chipRow}>
+              {memberIds.map((uid) => {
+                const member = memberMap[uid];
+                const selected = assignedTo.includes(uid);
+                return (
+                  <TouchableOpacity
+                    key={uid}
+                    style={[
+                      styles.chip,
+                      selected && { backgroundColor: member.color, borderColor: member.color },
+                    ]}
+                    onPress={() => toggleAssignee(uid)}
+                    activeOpacity={0.7}
+                  >
+                    <Text style={[styles.chipText, selected && styles.chipTextSelected]}>
+                      {member.displayName}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+          </View>
+        )}
 
         <TextInput
           style={styles.input}
@@ -166,6 +213,19 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
   },
   multiline: { height: 64, textAlignVertical: 'top' },
+  assigneeSection: { marginBottom: 12 },
+  label: { fontSize: 13, fontWeight: '600', color: '#636e72', marginBottom: 8 },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 20,
+    borderWidth: 1.5,
+    borderColor: '#DFE6E9',
+    backgroundColor: '#fff',
+  },
+  chipText: { fontSize: 13, fontWeight: '500', color: '#636e72' },
+  chipTextSelected: { color: '#fff', fontWeight: '600' },
   error: { color: '#E17055', fontSize: 13, marginBottom: 10 },
   button: {
     backgroundColor: '#2D3436',

--- a/src/firebase/firestore.ts
+++ b/src/firebase/firestore.ts
@@ -67,3 +67,6 @@ export const userDoc = (userId: string) =>
 
 export const houseDoc = (houseId: string) =>
   doc(db, 'houses', houseId).withConverter(houseConverter);
+
+export const eventDoc = (houseId: string, eventId: string) =>
+  doc(db, 'houses', houseId, 'events', eventId).withConverter(calendarEventConverter);

--- a/src/hooks/useCalendarEvents.ts
+++ b/src/hooks/useCalendarEvents.ts
@@ -1,9 +1,13 @@
 import { useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { onSnapshot, addDoc, serverTimestamp, Timestamp } from 'firebase/firestore';
-import { eventsCol } from '@/src/firebase/firestore';
+import { onSnapshot, addDoc, updateDoc, serverTimestamp, Timestamp } from 'firebase/firestore';
+import { eventsCol, eventDoc } from '@/src/firebase/firestore';
 import { useHouseStore } from '@/src/store/houseStore';
 import { useAuthStore } from '@/src/store/authStore';
+import {
+  getOrCreateHomieCalendar,
+  addEventToDeviceCalendar,
+} from '@/src/utils/calendarSync';
 import type { CalendarEvent } from '@/src/types';
 
 export interface NewEventInput {
@@ -11,6 +15,33 @@ export interface NewEventInput {
   description: string;
   startTime: Date;
   endTime: Date;
+  assignedTo: string[];
+}
+
+async function syncEventForCurrentUser(params: {
+  eventFirestoreId: string;
+  houseId: string;
+  userId: string;
+  title: string;
+  description: string;
+  startDate: Date;
+  endDate: Date;
+}): Promise<void> {
+  const calendarId = await getOrCreateHomieCalendar();
+  if (!calendarId) return;
+
+  const nativeId = await addEventToDeviceCalendar({
+    title: params.title,
+    description: params.description,
+    startDate: params.startDate,
+    endDate: params.endDate,
+    calendarId,
+  });
+  if (!nativeId) return;
+
+  await updateDoc(eventDoc(params.houseId, params.eventFirestoreId), {
+    [`deviceCalendarIds.${params.userId}`]: nativeId,
+  });
 }
 
 export function useCalendarEvents() {
@@ -37,23 +68,60 @@ export function useCalendarEvents() {
     return unsub;
   }, [houseId, queryClient]);
 
+  // Reconciliation: sync any assigned events that haven't been written to the device calendar yet
+  useEffect(() => {
+    if (!events.length || !userProfile || !houseId) return;
+
+    const unsynced = events.filter(
+      (e) =>
+        e.assignedTo?.includes(userProfile.id) &&
+        !e.deviceCalendarIds?.[userProfile.id]
+    );
+    if (!unsynced.length) return;
+
+    (async () => {
+      for (const event of unsynced) {
+        await syncEventForCurrentUser({
+          eventFirestoreId: event.id,
+          houseId,
+          userId: userProfile.id,
+          title: event.title,
+          description: event.description,
+          startDate: event.startTime.toDate(),
+          endDate: event.endTime.toDate(),
+        });
+      }
+    })();
+  }, [events, userProfile?.id, houseId]);
+
   const addEvent = async (input: NewEventInput) => {
     if (!houseId || !userProfile) throw new Error('No house connected. Join a house first.');
 
-    try {
-      await addDoc(eventsCol(houseId), {
-        id: '',
+    const docRef = await addDoc(eventsCol(houseId), {
+      id: '',
+      title: input.title,
+      description: input.description,
+      startTime: Timestamp.fromDate(input.startTime),
+      endTime: Timestamp.fromDate(input.endTime),
+      color: userProfile.color,
+      googleEventId: null,
+      assignedTo: input.assignedTo,
+      deviceCalendarIds: {},
+      createdBy: userProfile.id,
+      createdAt: serverTimestamp(),
+    } as any);
+
+    // Immediately sync to device calendar if the current user is assigned
+    if (input.assignedTo.includes(userProfile.id)) {
+      await syncEventForCurrentUser({
+        eventFirestoreId: docRef.id,
+        houseId,
+        userId: userProfile.id,
         title: input.title,
         description: input.description,
-        startTime: Timestamp.fromDate(input.startTime),
-        endTime: Timestamp.fromDate(input.endTime),
-        color: userProfile.color,
-        googleEventId: null,
-        createdBy: userProfile.id,
-        createdAt: serverTimestamp(),
-      } as any);
-    } catch (err) {
-      throw err;
+        startDate: input.startTime,
+        endDate: input.endTime,
+      });
     }
   };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,8 @@ export interface CalendarEvent {
   createdBy: string; // userId
   color: string; // denormalized from user.color at write time
   googleEventId: string | null;
+  assignedTo: string[]; // userIds; empty array = no assignees
+  deviceCalendarIds: Record<string, string>; // { [userId]: nativeCalendarEventId }
   createdAt: Timestamp;
 }
 

--- a/src/utils/calendarSync.ts
+++ b/src/utils/calendarSync.ts
@@ -1,0 +1,87 @@
+import * as Calendar from 'expo-calendar';
+import { Platform } from 'react-native';
+
+const HOMIE_CALENDAR_NAME = 'Homie';
+
+let cachedCalendarId: string | null | undefined = undefined;
+
+export async function getOrCreateHomieCalendar(): Promise<string | null> {
+  if (cachedCalendarId !== undefined) return cachedCalendarId;
+
+  const { status } = await Calendar.requestCalendarPermissionsAsync();
+  if (status !== 'granted') {
+    cachedCalendarId = null;
+    return null;
+  }
+
+  const calendars = await Calendar.getCalendarsAsync(Calendar.EntityTypes.EVENT);
+  const existing = calendars.find(
+    (c) => c.title === HOMIE_CALENDAR_NAME && c.allowsModifications
+  );
+
+  if (existing) {
+    cachedCalendarId = existing.id;
+    return existing.id;
+  }
+
+  // On iOS, use the default calendar source; on Android use the local source
+  const defaultSource =
+    Platform.OS === 'ios'
+      ? await getDefaultIOSSource(calendars)
+      : { isLocalAccount: true, name: 'Homie', type: Calendar.SourceType.LOCAL };
+
+  const newId = await Calendar.createCalendarAsync({
+    title: HOMIE_CALENDAR_NAME,
+    color: '#6C5CE7',
+    entityType: Calendar.EntityTypes.EVENT,
+    sourceId: Platform.OS === 'ios' ? (defaultSource as Calendar.Source).id : undefined,
+    source: Platform.OS === 'android' ? (defaultSource as Calendar.Source) : undefined,
+    name: HOMIE_CALENDAR_NAME,
+    ownerAccount: 'personal',
+    accessLevel: Calendar.CalendarAccessLevel.OWNER,
+  });
+
+  cachedCalendarId = newId;
+  return newId;
+}
+
+async function getDefaultIOSSource(
+  calendars: Calendar.Calendar[]
+): Promise<Calendar.Source> {
+  const sources = await Calendar.getSourcesAsync();
+  // Prefer iCloud, then the first writeable source
+  const icloud = sources.find((s) => s.type === Calendar.SourceType.CALDAV);
+  if (icloud) return icloud;
+  const local = sources.find((s) => s.type === Calendar.SourceType.LOCAL);
+  if (local) return local;
+  return sources[0];
+}
+
+export async function addEventToDeviceCalendar(params: {
+  title: string;
+  description: string;
+  startDate: Date;
+  endDate: Date;
+  calendarId: string;
+}): Promise<string | null> {
+  try {
+    const eventId = await Calendar.createEventAsync(params.calendarId, {
+      title: params.title,
+      notes: params.description,
+      startDate: params.startDate,
+      endDate: params.endDate,
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    });
+    return eventId;
+  } catch {
+    return null;
+  }
+}
+
+export async function removeEventFromDeviceCalendar(eventId: string): Promise<void> {
+  try {
+    await Calendar.deleteEventAsync(eventId);
+  } catch {
+    // ignore — event may have already been deleted by the user
+  }
+}


### PR DESCRIPTION
Closes #25

## What this does

Adds the ability to assign house members to calendar events. When you're assigned to an event, it's automatically written to your device's native calendar (iOS Calendar / Android Calendar), which syncs to Google Calendar if you have a Google account connected on your device — no OAuth, no API keys, no cost.

## Changes

- **`CalendarEvent` type** — two new fields: `assignedTo: string[]` and `deviceCalendarIds: Record<string, string>` (stores the native calendar event ID per user so we don't duplicate)
- **`src/utils/calendarSync.ts`** — new utility wrapping `expo-calendar`: creates a dedicated "Homie" calendar on the device, writes events, handles permissions
- **`useCalendarEvents`** — `addEvent` now accepts `assignedTo`, syncs immediately if current user is assigned; reconciliation effect catches any assigned events not yet on the device calendar (e.g. events created by another housemate while you were offline)
- **`EventForm`** — multi-select assignee chip row; each chip uses the member's color when selected
- **`EventCard`** — colored dot initials row showing who's assigned

## How to test

### Setup
1. Run on a **physical device or iOS/Android simulator** (`expo-calendar` is native only — this will not work on web)
2. Make sure you have at least one other member in your house so the assignee chips appear

### Test 1 — Assign yourself to a new event
1. Open the Calendar tab and tap **+**
2. Tap your name in the "Assign To" row — your chip should highlight in your color
3. Fill in a title, start time (`YYYY-MM-DD HH:MM`), and end time, then tap **Add Event**
4. When prompted, grant calendar access
5. Open your device's **Calendar app** → look for a "Homie" calendar → the event should be there
6. If you have Google Calendar with a Google account connected on the device, open it — the event syncs within ~30 seconds

### Test 2 — Assign a housemate (not yourself)
1. Create an event and tap a housemate's chip only (do not tap yourself)
2. No calendar permission prompt should appear — sync only fires for the current user
3. The event card should show the housemate's colored dot initial

### Test 3 — Reconciliation on app load
1. Sign into the app as Housemate A on a second device or simulator
2. From Housemate B's device, create an event with Housemate A assigned while A's device has the app closed
3. Open the app on Housemate A's device — the reconciliation effect detects the unsynced event and writes it to A's device calendar automatically

### Test 4 — Firestore
1. After syncing, open Firebase Console → `houses/{houseId}/events/{eventId}`
2. `assignedTo` should contain the correct userIds
3. `deviceCalendarIds` should have an entry for the synced user with a non-empty string value

### Test 5 — EventCard
1. Create an event with 2–3 assignees
2. The event card should show a row of small colored circle initials at the bottom

## Notes

Firestore security rules need a small update so assigned users can write back their `deviceCalendarIds` entry. Add to the events collection rule:

```
allow update: if request.auth.uid in resource.data.assignedTo
  && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['deviceCalendarIds']);
```