### PR TITLE
leavehouse backend update

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -11,11 +11,8 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-import { arrayRemove, deleteField, writeBatch } from 'firebase/firestore';
-
-import { db } from '@/src/firebase/config';
 import { signOut } from '@/src/firebase/auth';
-import { houseDoc, userDoc } from '@/src/firebase/firestore';
+import { leaveHouse } from '@/src/firebase/house';
 import { useAuthStore } from '@/src/store/authStore';
 import { useHouseStore } from '@/src/store/houseStore';
 
@@ -46,13 +43,7 @@ export default function SettingsScreen() {
     setLeaveError(null);
     setIsLeavingHouse(true);
     try {
-      const batch = writeBatch(db);
-      batch.update(houseDoc(houseId), {
-        memberIds: arrayRemove(currentUid),
-        [`memberNames.${currentUid}`]: deleteField(),
-      });
-      batch.update(userDoc(currentUid), { houseId: deleteField() });
-      await batch.commit();
+      await leaveHouse({ uid: currentUid, houseId });
       const profile = useAuthStore.getState().userProfile;
       if (profile) useAuthStore.getState().setUserProfile({ ...profile, houseId: null });
       useHouseStore.getState().setHouse(null);

--- a/src/firebase/house.ts
+++ b/src/firebase/house.ts
@@ -1,0 +1,13 @@
+import { arrayRemove, deleteField, writeBatch } from 'firebase/firestore';
+import { db } from './config';
+import { houseDoc, userDoc } from './firestore';
+
+export async function leaveHouse({ uid, houseId }: { uid: string; houseId: string }): Promise<void> {
+  const batch = writeBatch(db);
+  batch.update(houseDoc(houseId), {
+    memberIds: arrayRemove(uid),
+    [`memberNames.${uid}`]: deleteField(),
+  });
+  batch.update(userDoc(uid), { houseId: deleteField() });
+  await batch.commit();
+}


### PR DESCRIPTION
Closes #4 
made the leave house feature more clean so a user can cleanly exit a household they're part of. It does these 3 things backend on firebase. On the user's record, it clear out which house they belong to, on the house record it removes user's ID and name from the backend. 

