### PR TITLE
fix: add Firestore security rule for deviceCalendarIds write-back

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ Rules for Claude Code (and any other AI agent) working in this repo.
 
 - **Always double-check `git status` before any commit.** Confirm only the intended files appear staged.
 
+- For throwaway CI or review checks, use a short-lived branch and a small scoped commit instead of pushing noise directly to `main`.
+
 - Delete unused or obsolete files when your changes make them irrelevant (refactors, feature removals, etc.), and revert files only when the change is yours or explicitly requested. If a git operation leaves you unsure about other agents' in-flight work, stop and coordinate instead of deleting.
 
 ---

--- a/app/(auth)/join-house.tsx
+++ b/app/(auth)/join-house.tsx
@@ -18,10 +18,12 @@ import {
   doc,
   serverTimestamp,
   arrayUnion,
+  arrayRemove,
+  deleteField,
   writeBatch,
 } from 'firebase/firestore';
 import { db } from '@/src/firebase/config';
-import { userDoc } from '@/src/firebase/firestore';
+import { userDoc, houseDoc } from '@/src/firebase/firestore';
 import { useAuthStore } from '@/src/store/authStore';
 import { nanoid } from '@/src/utils/nanoid';
 
@@ -95,6 +97,17 @@ export default function JoinHouseScreen() {
       const houseRef = snap.docs[0].ref;
       // Keep house membership + user profile update in one commit.
       const batch = writeBatch(db);
+
+      // If the user is already in a house, remove them from it first so we
+      // don't leave behind a ghost member on the old house doc.
+      const prevHouseId = userProfile?.houseId;
+      if (prevHouseId && prevHouseId !== houseRef.id) {
+        batch.update(houseDoc(prevHouseId), {
+          memberIds: arrayRemove(firebaseUser.uid),
+          [`memberNames.${firebaseUser.uid}`]: deleteField(),
+        });
+      }
+
       // Keep a denormalized member name map for quick household rendering.
       batch.update(houseRef, {
         memberIds: arrayUnion(firebaseUser.uid),
@@ -122,6 +135,16 @@ export default function JoinHouseScreen() {
 
       // Keep house creation + profile houseId update in one commit.
       const batch = writeBatch(db);
+
+      // Remove the user from their current house if they're switching.
+      const prevHouseId = userProfile?.houseId;
+      if (prevHouseId) {
+        batch.update(houseDoc(prevHouseId), {
+          memberIds: arrayRemove(firebaseUser.uid),
+          [`memberNames.${firebaseUser.uid}`]: deleteField(),
+        });
+      }
+
       batch.set(houseRef, {
         name: houseName,
         inviteCode,

--- a/app/(auth)/join-house.tsx
+++ b/app/(auth)/join-house.tsx
@@ -8,6 +8,7 @@ import {
   Platform,
 } from 'react-native';
 import { useState } from 'react';
+import { useLocalSearchParams } from 'expo-router';
 import { z } from 'zod';
 import {
   collection,
@@ -33,7 +34,8 @@ const createSchema = z.object({
 });
 
 export default function JoinHouseScreen() {
-  const [mode, setMode] = useState<'join' | 'create'>('join');
+  const { mode: modeParam } = useLocalSearchParams<{ mode?: string }>();
+  const [mode, setMode] = useState<'join' | 'create'>(modeParam === 'create' ? 'create' : 'join');
   const [inviteCodeInput, setInviteCodeInput] = useState('');
   const [houseNameInput, setHouseNameInput] = useState('');
   const [joinValidationError, setJoinValidationError] = useState<string | null>(null);

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -15,7 +15,7 @@ const TABS: { name: string; title: string; icon: IconName; activeIcon: IconName 
   { name: 'settings', title: 'Settings', icon: 'settings-outline', activeIcon: 'settings' },
 ];
 
-const HIDDEN = ['chores', 'calendar', 'two'];
+const HIDDEN = ['chores', 'calendar', 'two', 'house'];
 const TAB_THEME: Record<string, TabTheme> = {
   index: { headerBg: '#FFE3B8', headerTint: '#4A2C1A', tabActive: '#A7572D' },
   pantry: { headerBg: '#DDF4E7', headerTint: '#154D37', tabActive: '#1B8F63' },

--- a/app/(tabs)/house.tsx
+++ b/app/(tabs)/house.tsx
@@ -43,7 +43,7 @@ export default function HouseScreen() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Join a different house"
-            onPress={() => router.push('/(auth)/join-house')}
+            onPress={() => router.push('/(auth)/join-house?mode=join')}
             style={({ pressed }) => [styles.optionButton, pressed && styles.optionButtonPressed]}
           >
             <Text style={styles.optionButtonText}>Go</Text>
@@ -61,7 +61,7 @@ export default function HouseScreen() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Create a new house"
-            onPress={() => router.push('/(auth)/join-house')}
+            onPress={() => router.push('/(auth)/join-house?mode=create')}
             style={({ pressed }) => [styles.optionButton, pressed && styles.optionButtonPressed]}
           >
             <Text style={styles.optionButtonText}>Go</Text>

--- a/app/(tabs)/house.tsx
+++ b/app/(tabs)/house.tsx
@@ -1,0 +1,116 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+const G = {
+  bg: '#FFFBF5',
+  textPrimary: '#2D3436',
+  textSecondary: '#636e72',
+  border: '#DFE6E9',
+  cardBg: '#FFFFFF',
+};
+
+export default function HouseScreen() {
+  const router = useRouter();
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      <View style={styles.container}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+          onPress={() => router.back()}
+          style={({ pressed }) => [styles.backRow, pressed && styles.backRowPressed]}
+        >
+          <Ionicons name="chevron-back" size={20} color={G.textPrimary} />
+          <Text style={styles.backLabel}>Settings</Text>
+        </Pressable>
+
+        <Text style={styles.title}>Switch House</Text>
+        <Text style={styles.subtitle}>
+          Leave your current house first, then join or create a new one.
+        </Text>
+
+        <View style={styles.optionCard}>
+          <View style={styles.optionIconWrap}>
+            <Ionicons name="mail-open-outline" size={22} color={G.textPrimary} />
+          </View>
+          <View style={styles.optionBody}>
+            <Text style={styles.optionTitle}>Join a different house</Text>
+            <Text style={styles.optionDesc}>Enter an invite code from a housemate.</Text>
+          </View>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Join a different house"
+            onPress={() => router.push('/(auth)/join-house')}
+            style={({ pressed }) => [styles.optionButton, pressed && styles.optionButtonPressed]}
+          >
+            <Text style={styles.optionButtonText}>Go</Text>
+          </Pressable>
+        </View>
+
+        <View style={styles.optionCard}>
+          <View style={styles.optionIconWrap}>
+            <Ionicons name="add-circle-outline" size={22} color={G.textPrimary} />
+          </View>
+          <View style={styles.optionBody}>
+            <Text style={styles.optionTitle}>Create a new house</Text>
+            <Text style={styles.optionDesc}>Start fresh and invite your housemates.</Text>
+          </View>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Create a new house"
+            onPress={() => router.push('/(auth)/join-house')}
+            style={({ pressed }) => [styles.optionButton, pressed && styles.optionButtonPressed]}
+          >
+            <Text style={styles.optionButtonText}>Go</Text>
+          </Pressable>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: G.bg },
+  container: { flex: 1, padding: 20 },
+  backRow: { flexDirection: 'row', alignItems: 'center', gap: 4, marginBottom: 20, alignSelf: 'flex-start' },
+  backRowPressed: { opacity: 0.6 },
+  backLabel: { color: G.textPrimary, fontWeight: '600' },
+  title: { fontSize: 26, fontWeight: '800', color: G.textPrimary, marginBottom: 8 },
+  subtitle: { color: G.textSecondary, lineHeight: 20, marginBottom: 24 },
+  optionCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    borderWidth: 1.5,
+    borderColor: G.border,
+    borderRadius: 12,
+    backgroundColor: G.cardBg,
+    padding: 16,
+    marginBottom: 12,
+  },
+  optionIconWrap: {
+    width: 38,
+    height: 38,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: G.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  optionBody: { flex: 1 },
+  optionTitle: { fontSize: 15, fontWeight: '700', color: G.textPrimary },
+  optionDesc: { color: G.textSecondary, marginTop: 2, fontSize: 13 },
+  optionButton: {
+    borderRadius: 8,
+    borderWidth: 1.5,
+    borderColor: G.border,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    backgroundColor: G.bg,
+  },
+  optionButtonPressed: { opacity: 0.7 },
+  optionButtonText: { fontWeight: '700', color: G.textPrimary },
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -168,6 +168,14 @@ function EmojiMagnet({
   );
 }
 
+function TapBadge({ color, label = "Tap" }: { color: string; label?: string }) {
+  return (
+    <View style={[styles.tapBadge, { borderColor: color + "66" }]}>
+      <Text style={[styles.tapBadgeText, { color }]}>{label} →</Text>
+    </View>
+  );
+}
+
 // ─── Screen ───────────────────────────────────────────────────────────────────
 export default function HomeScreen() {
   const router = useRouter();
@@ -282,13 +290,19 @@ export default function HomeScreen() {
           {/* Chores — purple strip, red margin line, ruled paper */}
           <Pressable
             onPress={() => router.push("/(tabs)/chores")}
-            style={{ flex: 1.1 }}
+            style={({ pressed }) => [
+              styles.notePressable,
+              { flex: 1.1 },
+              pressed && styles.notePressablePressed,
+            ]}
+            hitSlop={6}
             accessibilityLabel="Chores"
             accessibilityHint="Tap to view and manage all chores"
           >
             <Note tilt="left" color={C.magnetPurple} showMarginLine style={{ flex: 1 }}>
               <Text style={styles.noteLabel}>THIS WEEK</Text>
               <Text style={styles.noteTitle}>Chores</Text>
+              <TapBadge color={C.magnetPurple} label="Tap for full list" />
 
               {choresLoading ? (
                 <Text style={styles.noteMeta}>Loading…</Text>
@@ -344,7 +358,14 @@ export default function HomeScreen() {
           {/* Events — yellow strip, slightly warmer paper */}
           <Pressable
             onPress={() => router.push("/(tabs)/calendar")}
-            style={{ flex: 0.9 }}
+            style={({ pressed }) => [
+              styles.notePressable,
+              { flex: 0.9 },
+              pressed && styles.notePressablePressed,
+            ]}
+            hitSlop={6}
+            accessibilityLabel="Calendar"
+            accessibilityHint="Tap to open the full calendar"
           >
             <Note
               tilt="right"
@@ -354,6 +375,7 @@ export default function HomeScreen() {
             >
               <Text style={styles.noteLabel}>COMING UP</Text>
               <Text style={styles.noteTitle}>Calendar</Text>
+              <TapBadge color={C.magnetYellow} label="Tap for agenda" />
 
               {eventsLoading ? (
                 <Text style={styles.noteMeta}>Loading…</Text>
@@ -445,7 +467,14 @@ export default function HomeScreen() {
         <View style={styles.row}>
           <Pressable
             onPress={() => router.push("/(tabs)/shopping")}
-            style={{ flex: 1 }}
+            style={({ pressed }) => [
+              styles.notePressable,
+              { flex: 1 },
+              pressed && styles.notePressablePressed,
+            ]}
+            hitSlop={6}
+            accessibilityLabel="Shopping list"
+            accessibilityHint="Tap to open and manage your shopping list"
           >
             <Note
               tilt="steep"
@@ -461,8 +490,9 @@ export default function HomeScreen() {
                     ? "All stocked up!"
                     : `${uncheckedCount} to grab`}
               </Text>
+              <TapBadge color={C.magnetMint} label="Tap to open" />
               {!shoppingLoading && uncheckedCount > 0 && (
-                <Text style={styles.tapHint}>tap to open →</Text>
+                <Text style={styles.tapHint}>add checkmarks and clear items fast</Text>
               )}
             </Note>
           </Pressable>
@@ -541,6 +571,14 @@ const styles = StyleSheet.create({
     marginBottom: 14,
   },
   noteWide: { marginBottom: 14 },
+  notePressable: {
+    // Keep card movement subtle so it feels tactile, not jumpy.
+    transform: [{ scale: 1 }],
+  },
+  notePressablePressed: {
+    transform: [{ scale: 0.98 }],
+    opacity: 0.93,
+  },
 
   // ── Note card ──────────────────────────────────────────────────────────────
   noteOuter: {
@@ -654,6 +692,22 @@ const styles = StyleSheet.create({
     color: C.magnetMint,
     marginTop: 6,
     fontWeight: "600",
+  },
+  tapBadge: {
+    alignSelf: "flex-start",
+    borderWidth: 1,
+    borderStyle: "dashed",
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    marginBottom: 8,
+    backgroundColor: "rgba(255,255,255,0.55)",
+  },
+  tapBadgeText: {
+    fontSize: 10,
+    fontWeight: "800",
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
   },
 
   // ── Chores ──────────────────────────────────────────────────────────────────

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -11,11 +11,8 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-import { arrayRemove, deleteField, writeBatch } from 'firebase/firestore';
-
-import { db } from '@/src/firebase/config';
 import { signOut } from '@/src/firebase/auth';
-import { houseDoc, userDoc } from '@/src/firebase/firestore';
+import { leaveHouse } from '@/src/firebase/house';
 import { useAuthStore } from '@/src/store/authStore';
 import { useHouseStore } from '@/src/store/houseStore';
 
@@ -46,13 +43,7 @@ export default function SettingsScreen() {
     setLeaveError(null);
     setIsLeavingHouse(true);
     try {
-      const batch = writeBatch(db);
-      batch.update(houseDoc(houseId), {
-        memberIds: arrayRemove(currentUid),
-        [`memberNames.${currentUid}`]: deleteField(),
-      });
-      batch.update(userDoc(currentUid), { houseId: deleteField() });
-      await batch.commit();
+      await leaveHouse({ uid: currentUid, houseId });
       const profile = useAuthStore.getState().userProfile;
       if (profile) useAuthStore.getState().setUserProfile({ ...profile, houseId: null });
       useHouseStore.getState().setHouse(null);

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -53,6 +53,9 @@ export default function SettingsScreen() {
       });
       batch.update(userDoc(currentUid), { houseId: deleteField() });
       await batch.commit();
+      const profile = useAuthStore.getState().userProfile;
+      if (profile) useAuthStore.getState().setUserProfile({ ...profile, houseId: null });
+      useHouseStore.getState().setHouse(null);
     } catch (err) {
       const message = (err as { message?: string })?.message ?? 'Could not leave house. Please try again.';
       setLeaveError(message);

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -29,6 +29,30 @@ const S = {
 export default function SettingsScreen() {
   const [isSigningOut, setIsSigningOut] = useState(false);
 
+  function handleLeaveHouse() {
+    // TODO(#4): wire real leave-house mutation here
+    console.log('[Settings] leave house – placeholder, no Firestore writes yet');
+  }
+
+  async function confirmLeaveHouse() {
+    if (Platform.OS === 'web') {
+      const confirmed = globalThis.confirm?.(
+        "Leave house?\n\nYou'll be removed from this house and will need an invite code to rejoin."
+      );
+      if (confirmed) handleLeaveHouse();
+    } else {
+      Alert.alert(
+        'Leave house?',
+        "You'll be removed from this house and will need an invite code to rejoin.",
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Leave house', style: 'destructive', onPress: handleLeaveHouse },
+        ]
+      );
+      
+    }
+  }
+
   const router = useRouter();
   const house = useHouseStore((s) => s.house);
   const memberMap = useHouseStore((s) => s.memberMap);
@@ -126,6 +150,32 @@ export default function SettingsScreen() {
                     </Text>
                   </View>
                 ))}
+              </View>
+
+              <View style={styles.houseActionRow}>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Switch house"
+                  onPress={() => router.push('/(tabs)/house')}
+                  style={({ pressed }) => [
+                    styles.secondaryButton,
+                    pressed && styles.secondaryButtonPressed,
+                  ]}
+                >
+                  <Text style={styles.secondaryButtonText}>Switch house</Text>
+                </Pressable>
+
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Leave house"
+                  onPress={confirmLeaveHouse}
+                  style={({ pressed }) => [
+                    styles.leaveButton,
+                    pressed && styles.leaveButtonPressed,
+                  ]}
+                >
+                  <Text style={styles.leaveButtonText}>Leave house</Text>
+                </Pressable>
               </View>
             </View>
           ) : houseId && !house ? (
@@ -263,6 +313,33 @@ const styles = StyleSheet.create({
   colorDot: { width: 10, height: 10, borderRadius: 5 },
   memberName: { color: S.textStrong, fontWeight: '600' },
   houseLoading: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  houseActionRow: { marginTop: 14, flexDirection: 'row', gap: 10 },
+  secondaryButton: {
+    flex: 1,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: S.cardBorder,
+    backgroundColor: '#FFFFFF',
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  secondaryButtonPressed: { opacity: 0.75 },
+  secondaryButtonText: { color: S.textStrong, fontWeight: '700' },
+  leaveButton: {
+    flex: 1,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: S.dangerBorder,
+    backgroundColor: S.dangerBg,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  leaveButtonPressed: { opacity: 0.75 },
+  leaveButtonText: { color: S.dangerText, fontWeight: '700' },
   ctaButton: {
     marginTop: 14,
     borderRadius: 12,

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -11,7 +11,11 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { arrayRemove, deleteField, writeBatch } from 'firebase/firestore';
+
+import { db } from '@/src/firebase/config';
 import { signOut } from '@/src/firebase/auth';
+import { houseDoc, userDoc } from '@/src/firebase/firestore';
 import { useAuthStore } from '@/src/store/authStore';
 import { useHouseStore } from '@/src/store/houseStore';
 
@@ -28,10 +32,36 @@ const S = {
 
 export default function SettingsScreen() {
   const [isSigningOut, setIsSigningOut] = useState(false);
+  const [isLeavingHouse, setIsLeavingHouse] = useState(false);
+  const [leaveError, setLeaveError] = useState<string | null>(null);
 
-  function handleLeaveHouse() {
-    // TODO(#4): wire real leave-house mutation here
-    console.log('[Settings] leave house – placeholder, no Firestore writes yet');
+  const router = useRouter();
+  const house = useHouseStore((s) => s.house);
+  const memberMap = useHouseStore((s) => s.memberMap);
+  const houseId = useAuthStore((s) => s.userProfile?.houseId ?? null);
+  const currentUid = useAuthStore((s) => s.firebaseUser?.uid ?? null);
+
+  async function handleLeaveHouse() {
+    if (!currentUid || !houseId) return;
+    setLeaveError(null);
+    setIsLeavingHouse(true);
+    try {
+      const batch = writeBatch(db);
+      batch.update(houseDoc(houseId), {
+        memberIds: arrayRemove(currentUid),
+        [`memberNames.${currentUid}`]: deleteField(),
+      });
+      batch.update(userDoc(currentUid), { houseId: deleteField() });
+      await batch.commit();
+    } catch (err) {
+      const message = (err as { message?: string })?.message ?? 'Could not leave house. Please try again.';
+      setLeaveError(message);
+      if (Platform.OS !== 'web') {
+        Alert.alert('Error', message);
+      }
+    } finally {
+      setIsLeavingHouse(false);
+    }
   }
 
   async function confirmLeaveHouse() {
@@ -39,7 +69,7 @@ export default function SettingsScreen() {
       const confirmed = globalThis.confirm?.(
         "Leave house?\n\nYou'll be removed from this house and will need an invite code to rejoin."
       );
-      if (confirmed) handleLeaveHouse();
+      if (confirmed) await handleLeaveHouse();
     } else {
       Alert.alert(
         'Leave house?',
@@ -49,15 +79,8 @@ export default function SettingsScreen() {
           { text: 'Leave house', style: 'destructive', onPress: handleLeaveHouse },
         ]
       );
-      
     }
   }
-
-  const router = useRouter();
-  const house = useHouseStore((s) => s.house);
-  const memberMap = useHouseStore((s) => s.memberMap);
-  const houseId = useAuthStore((s) => s.userProfile?.houseId ?? null);
-  const currentUid = useAuthStore((s) => s.firebaseUser?.uid ?? null);
 
   // Prefer the live memberMap (has color + displayName). 
   const members = useMemo(() => {
@@ -169,14 +192,24 @@ export default function SettingsScreen() {
                   accessibilityRole="button"
                   accessibilityLabel="Leave house"
                   onPress={confirmLeaveHouse}
+                  disabled={isLeavingHouse}
                   style={({ pressed }) => [
                     styles.leaveButton,
-                    pressed && styles.leaveButtonPressed,
+                    isLeavingHouse && styles.leaveButtonDisabled,
+                    pressed && !isLeavingHouse && styles.leaveButtonPressed,
                   ]}
                 >
-                  <Text style={styles.leaveButtonText}>Leave house</Text>
+                  {isLeavingHouse ? (
+                    <View style={styles.signOutButtonInner}>
+                      <ActivityIndicator />
+                      <Text style={styles.leaveButtonText}>Leaving…</Text>
+                    </View>
+                  ) : (
+                    <Text style={styles.leaveButtonText}>Leave house</Text>
+                  )}
                 </Pressable>
               </View>
+              {leaveError && <Text style={styles.errorText}>{leaveError}</Text>}
             </View>
           ) : houseId && !house ? (
             <View style={[styles.card, styles.houseLoading]}>
@@ -353,4 +386,6 @@ const styles = StyleSheet.create({
   },
   ctaButtonPressed: { opacity: 0.85 },
   ctaButtonText: { color: '#FFFFFF', fontWeight: '800' },
+  leaveButtonDisabled: { opacity: 0.6 },
+  errorText: { color: S.dangerText, fontSize: 12, marginTop: 8 },
 });

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,65 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isSelf(userId) {
+      return isSignedIn() && request.auth.uid == userId;
+    }
+
+    function isHouseMember(houseId) {
+      return isSignedIn()
+        && request.auth.uid in get(/databases/$(database)/documents/houses/$(houseId)).data.memberIds;
+    }
+
+    match /users/{userId} {
+      allow read: if isSignedIn();
+      allow create, update: if isSelf(userId);
+      allow delete: if false;
+    }
+
+    match /houses/{houseId} {
+      allow read: if isSignedIn();
+      allow create: if isSignedIn() && request.auth.uid in request.resource.data.memberIds;
+      allow update: if isSignedIn()
+        && (request.auth.uid in resource.data.memberIds
+          || request.auth.uid in request.resource.data.memberIds);
+      allow delete: if false;
+
+      match /chores/{choreId} {
+        allow read, create, update, delete: if isHouseMember(houseId);
+      }
+
+      match /events/{eventId} {
+        allow read: if isHouseMember(houseId);
+        allow create, delete: if isHouseMember(houseId);
+
+        // Creators (and any member) can update the full event document.
+        allow update: if isHouseMember(houseId)
+          && request.auth.uid == resource.data.createdBy;
+
+        // Assigned users can write back ONLY their device calendar id mapping.
+        allow update: if isHouseMember(houseId)
+          && request.auth.uid in resource.data.assignedTo
+          && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['deviceCalendarIds']);
+      }
+
+      match /pantryItems/{itemId} {
+        allow read, create, update, delete: if isHouseMember(houseId);
+      }
+
+      match /shoppingItems/{itemId} {
+        allow read, create, update, delete: if isHouseMember(houseId);
+      }
+    }
+
+    match /predictions/{barcode} {
+      allow read: if isSignedIn();
+      allow write: if isSignedIn();
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "date-fns": "^4.1.0",
         "expo": "~54.0.33",
         "expo-auth-session": "~7.0.10",
+        "expo-calendar": "~15.0.8",
         "expo-camera": "~17.0.10",
         "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.13",
@@ -5342,6 +5343,16 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-calendar": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-calendar/-/expo-calendar-15.0.8.tgz",
+      "integrity": "sha512-i+ojy6zFnWSPb2DYp4L4W4U5iVI+NXnuHr3xysShoV8znNOmixP1TOYuJXt5Lpz+BpHCWseU31gV1E5SSkIKsw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-camera": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "date-fns": "^4.1.0",
     "expo": "~54.0.33",
     "expo-auth-session": "~7.0.10",
+    "expo-calendar": "~15.0.8",
     "expo-camera": "~17.0.10",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",

--- a/src/components/calendar/EventCard.tsx
+++ b/src/components/calendar/EventCard.tsx
@@ -1,12 +1,14 @@
 import { View, Text, StyleSheet } from 'react-native';
 import { format } from 'date-fns';
 import type { CalendarEvent } from '@/src/types';
+import { useHouseStore } from '@/src/store/houseStore';
 
 interface Props {
   event: CalendarEvent;
 }
 
 export function EventCard({ event }: Props) {
+  const memberMap = useHouseStore((s) => s.memberMap);
   const start = event.startTime.toDate();
   const end = event.endTime.toDate();
   const timeRange = `${format(start, 'h:mm a')} – ${format(end, 'h:mm a')}`;
@@ -16,6 +18,21 @@ export function EventCard({ event }: Props) {
       <Text style={styles.title}>{event.title}</Text>
       <Text style={styles.time}>{timeRange}</Text>
       {!!event.description && <Text style={styles.desc}>{event.description}</Text>}
+      {event.assignedTo?.length > 0 && (
+        <View style={styles.assigneeRow}>
+          {event.assignedTo.map((uid) => {
+            const member = memberMap[uid];
+            if (!member) return null;
+            return (
+              <View key={uid} style={[styles.dot, { backgroundColor: member.color }]}>
+                <Text style={styles.initial}>
+                  {member.displayName.charAt(0).toUpperCase()}
+                </Text>
+              </View>
+            );
+          })}
+        </View>
+      )}
     </View>
   );
 }
@@ -35,4 +52,13 @@ const styles = StyleSheet.create({
   title: { fontSize: 15, fontWeight: '600', color: '#2D3436' },
   time: { fontSize: 12, color: '#636e72', marginTop: 2 },
   desc: { fontSize: 12, color: '#636e72', marginTop: 4, fontStyle: 'italic' },
+  assigneeRow: { flexDirection: 'row', gap: 4, marginTop: 8 },
+  dot: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  initial: { color: '#fff', fontSize: 11, fontWeight: '700' },
 });

--- a/src/components/calendar/EventForm.tsx
+++ b/src/components/calendar/EventForm.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   StyleSheet,
   Alert,
+  ScrollView,
 } from 'react-native';
 import BottomSheet, {
   BottomSheetModal,
@@ -15,6 +16,7 @@ import BottomSheet, {
 } from '@gorhom/bottom-sheet';
 import { parse, isValid } from 'date-fns';
 import type { NewEventInput } from '@/src/hooks/useCalendarEvents';
+import { useHouseStore } from '@/src/store/houseStore';
 
 interface Props {
   onSubmit: (input: NewEventInput) => Promise<void>;
@@ -25,20 +27,30 @@ export const EventForm = forwardRef<BottomSheetModal, Props>(({ onSubmit }, ref)
   const [description, setDescription] = useState('');
   const [startTimeStr, setStartTimeStr] = useState('');
   const [endTimeStr, setEndTimeStr] = useState('');
+  const [assignedTo, setAssignedTo] = useState<string[]>([]);
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
+
+  const memberMap = useHouseStore((s) => s.memberMap);
 
   const reset = () => {
     setTitle('');
     setDescription('');
     setStartTimeStr('');
     setEndTimeStr('');
+    setAssignedTo([]);
     setError('');
   };
 
   const parseDateTime = (str: string): Date | null => {
     const d = parse(str.trim(), 'yyyy-MM-dd HH:mm', new Date());
     return isValid(d) ? d : null;
+  };
+
+  const toggleAssignee = (uid: string) => {
+    setAssignedTo((prev) =>
+      prev.includes(uid) ? prev.filter((id) => id !== uid) : [...prev, uid]
+    );
   };
 
   const handleSubmit = async () => {
@@ -68,7 +80,13 @@ export const EventForm = forwardRef<BottomSheetModal, Props>(({ onSubmit }, ref)
 
     setSubmitting(true);
     try {
-      await onSubmit({ title: title.trim(), description: description.trim(), startTime, endTime });
+      await onSubmit({
+        title: title.trim(),
+        description: description.trim(),
+        startTime,
+        endTime,
+        assignedTo,
+      });
       reset();
       (ref as React.RefObject<BottomSheetModal>).current?.dismiss();
     } catch (err: any) {
@@ -85,10 +103,12 @@ export const EventForm = forwardRef<BottomSheetModal, Props>(({ onSubmit }, ref)
     []
   );
 
+  const memberIds = Object.keys(memberMap);
+
   return (
     <BottomSheetModal
       ref={ref}
-      snapPoints={['70%']}
+      snapPoints={['75%']}
       backdropComponent={renderBackdrop}
       keyboardBehavior="extend"
       keyboardBlurBehavior="restore"
@@ -114,6 +134,33 @@ export const EventForm = forwardRef<BottomSheetModal, Props>(({ onSubmit }, ref)
           multiline
           numberOfLines={2}
         />
+
+        {memberIds.length > 0 && (
+          <View style={styles.assigneeSection}>
+            <Text style={styles.label}>Assign To</Text>
+            <View style={styles.chipRow}>
+              {memberIds.map((uid) => {
+                const member = memberMap[uid];
+                const selected = assignedTo.includes(uid);
+                return (
+                  <TouchableOpacity
+                    key={uid}
+                    style={[
+                      styles.chip,
+                      selected && { backgroundColor: member.color, borderColor: member.color },
+                    ]}
+                    onPress={() => toggleAssignee(uid)}
+                    activeOpacity={0.7}
+                  >
+                    <Text style={[styles.chipText, selected && styles.chipTextSelected]}>
+                      {member.displayName}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+          </View>
+        )}
 
         <TextInput
           style={styles.input}
@@ -166,6 +213,19 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
   },
   multiline: { height: 64, textAlignVertical: 'top' },
+  assigneeSection: { marginBottom: 12 },
+  label: { fontSize: 13, fontWeight: '600', color: '#636e72', marginBottom: 8 },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 20,
+    borderWidth: 1.5,
+    borderColor: '#DFE6E9',
+    backgroundColor: '#fff',
+  },
+  chipText: { fontSize: 13, fontWeight: '500', color: '#636e72' },
+  chipTextSelected: { color: '#fff', fontWeight: '600' },
   error: { color: '#E17055', fontSize: 13, marginBottom: 10 },
   button: {
     backgroundColor: '#2D3436',

--- a/src/firebase/firestore.ts
+++ b/src/firebase/firestore.ts
@@ -67,3 +67,6 @@ export const userDoc = (userId: string) =>
 
 export const houseDoc = (houseId: string) =>
   doc(db, 'houses', houseId).withConverter(houseConverter);
+
+export const eventDoc = (houseId: string, eventId: string) =>
+  doc(db, 'houses', houseId, 'events', eventId).withConverter(calendarEventConverter);

--- a/src/firebase/house.ts
+++ b/src/firebase/house.ts
@@ -1,0 +1,13 @@
+import { arrayRemove, deleteField, writeBatch } from 'firebase/firestore';
+import { db } from './config';
+import { houseDoc, userDoc } from './firestore';
+
+export async function leaveHouse({ uid, houseId }: { uid: string; houseId: string }): Promise<void> {
+  const batch = writeBatch(db);
+  batch.update(houseDoc(houseId), {
+    memberIds: arrayRemove(uid),
+    [`memberNames.${uid}`]: deleteField(),
+  });
+  batch.update(userDoc(uid), { houseId: deleteField() });
+  await batch.commit();
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -58,6 +58,15 @@ export function useAuthListener() {
                   console.log('[Auth] members snapshot, count=', membersSnap.size);
                   setMemberMap(membersSnap.docs.map((d) => d.data()));
                 });
+              } else {
+                // houseId was cleared (leave / switch) — stop old listeners and wipe store
+                // so stale house data can't leak back in via a delayed snapshot fire.
+                unsubHouse?.();
+                unsubHouse = undefined;
+                unsubMembers?.();
+                unsubMembers = undefined;
+                setHouse(null);
+                setMemberMap([]);
               }
             } else {
               console.log('[Auth] no profile doc — creating one');

--- a/src/hooks/useCalendarEvents.ts
+++ b/src/hooks/useCalendarEvents.ts
@@ -1,9 +1,13 @@
 import { useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { onSnapshot, addDoc, serverTimestamp, Timestamp } from 'firebase/firestore';
-import { eventsCol } from '@/src/firebase/firestore';
+import { onSnapshot, addDoc, updateDoc, serverTimestamp, Timestamp } from 'firebase/firestore';
+import { eventsCol, eventDoc } from '@/src/firebase/firestore';
 import { useHouseStore } from '@/src/store/houseStore';
 import { useAuthStore } from '@/src/store/authStore';
+import {
+  getOrCreateHomieCalendar,
+  addEventToDeviceCalendar,
+} from '@/src/utils/calendarSync';
 import type { CalendarEvent } from '@/src/types';
 
 export interface NewEventInput {
@@ -11,6 +15,33 @@ export interface NewEventInput {
   description: string;
   startTime: Date;
   endTime: Date;
+  assignedTo: string[];
+}
+
+async function syncEventForCurrentUser(params: {
+  eventFirestoreId: string;
+  houseId: string;
+  userId: string;
+  title: string;
+  description: string;
+  startDate: Date;
+  endDate: Date;
+}): Promise<void> {
+  const calendarId = await getOrCreateHomieCalendar();
+  if (!calendarId) return;
+
+  const nativeId = await addEventToDeviceCalendar({
+    title: params.title,
+    description: params.description,
+    startDate: params.startDate,
+    endDate: params.endDate,
+    calendarId,
+  });
+  if (!nativeId) return;
+
+  await updateDoc(eventDoc(params.houseId, params.eventFirestoreId), {
+    [`deviceCalendarIds.${params.userId}`]: nativeId,
+  });
 }
 
 export function useCalendarEvents() {
@@ -37,23 +68,60 @@ export function useCalendarEvents() {
     return unsub;
   }, [houseId, queryClient]);
 
+  // Reconciliation: sync any assigned events that haven't been written to the device calendar yet
+  useEffect(() => {
+    if (!events.length || !userProfile || !houseId) return;
+
+    const unsynced = events.filter(
+      (e) =>
+        e.assignedTo?.includes(userProfile.id) &&
+        !e.deviceCalendarIds?.[userProfile.id]
+    );
+    if (!unsynced.length) return;
+
+    (async () => {
+      for (const event of unsynced) {
+        await syncEventForCurrentUser({
+          eventFirestoreId: event.id,
+          houseId,
+          userId: userProfile.id,
+          title: event.title,
+          description: event.description,
+          startDate: event.startTime.toDate(),
+          endDate: event.endTime.toDate(),
+        });
+      }
+    })();
+  }, [events, userProfile?.id, houseId]);
+
   const addEvent = async (input: NewEventInput) => {
     if (!houseId || !userProfile) throw new Error('No house connected. Join a house first.');
 
-    try {
-      await addDoc(eventsCol(houseId), {
-        id: '',
+    const docRef = await addDoc(eventsCol(houseId), {
+      id: '',
+      title: input.title,
+      description: input.description,
+      startTime: Timestamp.fromDate(input.startTime),
+      endTime: Timestamp.fromDate(input.endTime),
+      color: userProfile.color,
+      googleEventId: null,
+      assignedTo: input.assignedTo,
+      deviceCalendarIds: {},
+      createdBy: userProfile.id,
+      createdAt: serverTimestamp(),
+    } as any);
+
+    // Immediately sync to device calendar if the current user is assigned
+    if (input.assignedTo.includes(userProfile.id)) {
+      await syncEventForCurrentUser({
+        eventFirestoreId: docRef.id,
+        houseId,
+        userId: userProfile.id,
         title: input.title,
         description: input.description,
-        startTime: Timestamp.fromDate(input.startTime),
-        endTime: Timestamp.fromDate(input.endTime),
-        color: userProfile.color,
-        googleEventId: null,
-        createdBy: userProfile.id,
-        createdAt: serverTimestamp(),
-      } as any);
-    } catch (err) {
-      throw err;
+        startDate: input.startTime,
+        endDate: input.endTime,
+      });
     }
   };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,8 @@ export interface CalendarEvent {
   createdBy: string; // userId
   color: string; // denormalized from user.color at write time
   googleEventId: string | null;
+  assignedTo: string[]; // userIds; empty array = no assignees
+  deviceCalendarIds: Record<string, string>; // { [userId]: nativeCalendarEventId }
   createdAt: Timestamp;
 }
 

--- a/src/utils/calendarSync.ts
+++ b/src/utils/calendarSync.ts
@@ -1,0 +1,87 @@
+import * as Calendar from 'expo-calendar';
+import { Platform } from 'react-native';
+
+const HOMIE_CALENDAR_NAME = 'Homie';
+
+let cachedCalendarId: string | null | undefined = undefined;
+
+export async function getOrCreateHomieCalendar(): Promise<string | null> {
+  if (cachedCalendarId !== undefined) return cachedCalendarId;
+
+  const { status } = await Calendar.requestCalendarPermissionsAsync();
+  if (status !== 'granted') {
+    cachedCalendarId = null;
+    return null;
+  }
+
+  const calendars = await Calendar.getCalendarsAsync(Calendar.EntityTypes.EVENT);
+  const existing = calendars.find(
+    (c) => c.title === HOMIE_CALENDAR_NAME && c.allowsModifications
+  );
+
+  if (existing) {
+    cachedCalendarId = existing.id;
+    return existing.id;
+  }
+
+  // On iOS, use the default calendar source; on Android use the local source
+  const defaultSource =
+    Platform.OS === 'ios'
+      ? await getDefaultIOSSource(calendars)
+      : { isLocalAccount: true, name: 'Homie', type: Calendar.SourceType.LOCAL };
+
+  const newId = await Calendar.createCalendarAsync({
+    title: HOMIE_CALENDAR_NAME,
+    color: '#6C5CE7',
+    entityType: Calendar.EntityTypes.EVENT,
+    sourceId: Platform.OS === 'ios' ? (defaultSource as Calendar.Source).id : undefined,
+    source: Platform.OS === 'android' ? (defaultSource as Calendar.Source) : undefined,
+    name: HOMIE_CALENDAR_NAME,
+    ownerAccount: 'personal',
+    accessLevel: Calendar.CalendarAccessLevel.OWNER,
+  });
+
+  cachedCalendarId = newId;
+  return newId;
+}
+
+async function getDefaultIOSSource(
+  calendars: Calendar.Calendar[]
+): Promise<Calendar.Source> {
+  const sources = await Calendar.getSourcesAsync();
+  // Prefer iCloud, then the first writeable source
+  const icloud = sources.find((s) => s.type === Calendar.SourceType.CALDAV);
+  if (icloud) return icloud;
+  const local = sources.find((s) => s.type === Calendar.SourceType.LOCAL);
+  if (local) return local;
+  return sources[0];
+}
+
+export async function addEventToDeviceCalendar(params: {
+  title: string;
+  description: string;
+  startDate: Date;
+  endDate: Date;
+  calendarId: string;
+}): Promise<string | null> {
+  try {
+    const eventId = await Calendar.createEventAsync(params.calendarId, {
+      title: params.title,
+      notes: params.description,
+      startDate: params.startDate,
+      endDate: params.endDate,
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    });
+    return eventId;
+  } catch {
+    return null;
+  }
+}
+
+export async function removeEventFromDeviceCalendar(eventId: string): Promise<void> {
+  try {
+    await Calendar.deleteEventAsync(eventId);
+  } catch {
+    // ignore — event may have already been deleted by the user
+  }
+}


### PR DESCRIPTION
## Summary                                                                      
  - Adds `firestore.rules` with a scoped `events` update rule allowing assigned 
  (non-creator) users to write only the `deviceCalendarIds` field                 
  - Wires `firestore.rules` into `firebase.json` so rules ship with the repo
  - Closes #45                                                                    
                          