### PR TITLE
fix: add Firestore security rule for deviceCalendarIds write-back

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,65 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isSelf(userId) {
+      return isSignedIn() && request.auth.uid == userId;
+    }
+
+    function isHouseMember(houseId) {
+      return isSignedIn()
+        && request.auth.uid in get(/databases/$(database)/documents/houses/$(houseId)).data.memberIds;
+    }
+
+    match /users/{userId} {
+      allow read: if isSignedIn();
+      allow create, update: if isSelf(userId);
+      allow delete: if false;
+    }
+
+    match /houses/{houseId} {
+      allow read: if isSignedIn();
+      allow create: if isSignedIn() && request.auth.uid in request.resource.data.memberIds;
+      allow update: if isSignedIn()
+        && (request.auth.uid in resource.data.memberIds
+          || request.auth.uid in request.resource.data.memberIds);
+      allow delete: if false;
+
+      match /chores/{choreId} {
+        allow read, create, update, delete: if isHouseMember(houseId);
+      }
+
+      match /events/{eventId} {
+        allow read: if isHouseMember(houseId);
+        allow create, delete: if isHouseMember(houseId);
+
+        // Creators (and any member) can update the full event document.
+        allow update: if isHouseMember(houseId)
+          && request.auth.uid == resource.data.createdBy;
+
+        // Assigned users can write back ONLY their device calendar id mapping.
+        allow update: if isHouseMember(houseId)
+          && request.auth.uid in resource.data.assignedTo
+          && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['deviceCalendarIds']);
+      }
+
+      match /pantryItems/{itemId} {
+        allow read, create, update, delete: if isHouseMember(houseId);
+      }
+
+      match /shoppingItems/{itemId} {
+        allow read, create, update, delete: if isHouseMember(houseId);
+      }
+    }
+
+    match /predictions/{barcode} {
+      allow read: if isSignedIn();
+      allow write: if isSignedIn();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `firestore.rules` with a scoped `events` update rule allowing assigned (non-creator) users to write only the `deviceCalendarIds` field
- Wires `firestore.rules` into `firebase.json` so rules ship with the repo
- Closes #45
