### PR TITLE
docs: drop staging branch references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ There are no lint or test scripts configured yet.
 
 ## Implementation Status
 
-All core features are implemented on the `staging` branch with real Firestore integrations. `main` holds the earlier foundation (auth, routing, design system only).
+All core features are implemented on `main` with real Firestore integrations.
 
 | Feature | Screen | Hook | Components | Status |
 |---|---|---|---|---|
@@ -33,7 +33,7 @@ Not yet built: Firebase Cloud Functions (weekly chore reset, expiration alerts),
 
 ## Current State & Known Issues (as of 2026-04-14)
 
-**Branch:** `staging` — actively being tested on `localhost:8081` via `npm run web`.
+**Branch:** `main` — actively being tested on `localhost:8081` via `npm run web`.
 
 ### Temporary code in place — must be cleaned up
 
@@ -54,7 +54,6 @@ The login redirect was broken — after a valid sign-in, the user stayed on the 
 2. Test that all 4 tabs load real Firestore data once a house exists
 3. Remove debug logs from `useAuth.ts` and `_layout.tsx`
 4. Restore join-house gate in `_layout.tsx`
-5. Merge `staging` → `main` once all tabs verified
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,10 @@ EXPO_PUBLIC_FIREBASE_APP_ID=...
 
 ### 4. Branch, PR, and commit conventions
 
-- **Base branch**: branch off `staging`, not `main`. `main` is behind.
+- **Base branch**: branch off `main`.
 - **Branch names**: `feature/<name>`, `fix/<short-description>`, `docs/<short-description>`
 - **PR scope**: one feature or fix per PR. Do not bundle unrelated changes.
-- **Stability**: keep `staging` green. Do not merge a PR that breaks the dev server or leaves the app in a visibly broken state.
+- **Stability**: keep `main` green. Do not merge a PR that breaks the dev server or leaves the app in a visibly broken state.
 - **Commit messages**: use Conventional-Commits style prefixes, e.g.
   - `docs: add Firebase onboarding to contributing`
   - `feat: add pantry item delete action`


### PR DESCRIPTION
## Summary

Removes mentions of `staging` from `CLAUDE.md` and `CONTRIBUTING.md` as part of consolidating onto a single `main` branch (see #57).

- `CLAUDE.md`: rewords the implementation status note, updates the testing branch to `main`, drops the now-obsolete "merge staging → main" step
- `CONTRIBUTING.md`: branch-off instruction now says `main`, stability rule now applies to `main`

## Test plan

- [ ] Verify both files render correctly on GitHub
- [ ] No other repo files reference `staging` (workflows checked — `gemini-review.yml` triggers on any `pull_request` and is unaffected)